### PR TITLE
refactor: Update collection initialization checks in CategoriesService

### DIFF
--- a/app/categories/service.py
+++ b/app/categories/service.py
@@ -36,7 +36,7 @@ class CategoriesService:
 
     async def _get_tools_collection(self) -> AsyncIOMotorCollection:
         """Get the tools collection"""
-        if not self.tools_collection:
+        if self.tools_collection is None:
             self.tools_collection = database.client.get_database(
                 "taaft_db"
             ).get_collection("tools")
@@ -44,7 +44,7 @@ class CategoriesService:
 
     async def _get_categories_collection(self) -> AsyncIOMotorCollection:
         """Get the categories collection"""
-        if not self.categories_collection:
+        if self.categories_collection is None:
             # Get database connection
             db = database.client.get_database("taaft_db")
 


### PR DESCRIPTION
This pull request makes a small but important change to improve the clarity and correctness of conditional checks when initializing database collections in the `app/categories/service.py` file.

* Updated conditional checks in `_get_tools_collection` and `_get_categories_collection` methods to use `is None` instead of `not` for checking if `tools_collection` and `categories_collection` are uninitialized. This ensures explicit and accurate null checks.- Changed the condition for initializing `tools_collection` and `categories_collection` to check for `None` instead of a truthy value, improving clarity and ensuring proper initialization logic.